### PR TITLE
Expose neo4j-browser ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,9 @@ services:
       - MOCK=false
 
   neo4j:
+    ports:
+      - 7687:7687
+      - 7474:7474
     build:
       context: .
       dockerfile: Dockerfile.neo4j


### PR DESCRIPTION
This helps developers to access the neo4j database from the browser.
Visit http://localhost:7474/ to see it in action.